### PR TITLE
QueryInspector: Fix deprecated call to Statement::execute()

### DIFF
--- a/src/QueryInspector.php
+++ b/src/QueryInspector.php
@@ -29,6 +29,6 @@ class QueryInspector
         $connection = $this->entityManager->getConnection();
 
         $statement = $connection->prepare($this->query);
-        $statement->execute($this->queryParameters);
+        $statement->executeQuery($this->queryParameters);
     }
 }

--- a/tests/QueryInspectorTest.php
+++ b/tests/QueryInspectorTest.php
@@ -24,7 +24,7 @@ class QueryInspectorTest extends TestCase
     {
         $statement = \Mockery::mock(Statement::class);
         $statement
-            ->shouldReceive('execute')
+            ->shouldReceive('executeQuery')
             ->with($queryParameters)
         ;
 


### PR DESCRIPTION
Fixes #17